### PR TITLE
Feature/cycle time basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ TODO
 ➜  vsts-flow-metrics git:(master) ✗ export VSTS_INSTANCE=msmobilecenter.visualstudio.com
 ```
 
+## REPL
+
+
+```clojure
+(in-ns 'vsts-flow-metrics.core)
+
+;; cache and save all updates to features closed the last 30 days
+(def features-closed-30d (storage/load-state-changes-from-cache
+                           (storage/cache-changes "wiql/closed-features-30d.wiql" "Mobile-Center")))
+
+;; in the future you can just look in cache and find the timestamped json file, e.g.,
+(def features-closed-30d
+    (storage/load-state-changes-from-cache
+        "2018-03-22T03:18-closed-features-30d.wiql.json"))
+
+;; compute the time intervals that the features where in each state
+(def features-closed-30d-ints (intervals-in-state features-closed-30d))
+
+(clojure.pprint/pprint (first features-closed-30d-ints))
+
+```
 # License
 Copyright © 2018 Karl Krukow
 

--- a/src/vsts_flow_metrics/api.clj
+++ b/src/vsts_flow_metrics/api.clj
@@ -1,0 +1,65 @@
+(ns vsts-flow-metrics.api
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clj-http.client :as client]
+            [vsts-flow-metrics.config :as cfg]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [cheshire.core :as json]))
+
+
+(defn- work-items-url
+  ([instance ids]
+   (str "https://" (:name instance)
+        "/DefaultCollection/_apis/wit/workitems?api-version=3.0-preview&ids=" (string/join "," ids)
+        "&$expand=relations&ErrorPolicy=omit"))
+  ([instance ids as-of]
+   (str "https://" (:name instance)
+        "/DefaultCollection/_apis/wit/workitems?api-version=3.0-preview&ids=" (string/join "," ids)
+        "&asOf=" (f/unparse (f/formatter :date-time) as-of)
+        "&$expand=relations&ErrorPolicy=omit")))
+
+(defn- work-item-updates-url [instance id]
+  (str "https://" (:name instance)
+       "/_apis/wit/workitems/" id "/updates?api-version=3.0-preview"))
+
+
+(defn- wiql-url [instance project]
+  (str "https://" (:name instance)
+       "/DefaultCollection/" project "/_apis/wit/wiql?api-version=3.0-preview"))
+
+
+(defn get-work-items
+  ([instance ids]
+   (let [response (client/get (work-items-url instance ids)
+                              (:http-options instance))]
+     (json/parse-string (:body response) true)))
+  ([instance ids as-of]
+   (let [response (client/get (work-items-url instance ids as-of)
+                              (:http-options instance))]
+     (json/parse-string (:body response) true))))
+
+(defn query-work-items
+  [instance project query]
+  (let [response
+        (client/post (wiql-url instance project)
+                     (merge
+                      (:http-options instance)
+                      {:form-params {:query query} :content-type :json}))]
+    (json/parse-string (:body response) true)))
+
+(defn get-work-item-updates [instance id]
+  (let [response (client/get (work-item-updates-url instance id)
+                             (:http-options instance))]
+    (json/parse-string (:body response) true)))
+
+(defn get-work-item-state-changes [instance id]
+  (let [response (client/get (work-item-updates-url instance id)
+                             (merge (:http-options instance)
+                                    {:throw-exceptions false}))
+        item-updates (json/parse-string (:body response) true)]
+    (filter
+     (fn [{fields :fields}]
+       (or (:System.State fields)
+           (:System.BoardColumn fields)))
+     (:value item-updates))))

--- a/src/vsts_flow_metrics/charts.clj
+++ b/src/vsts_flow_metrics/charts.clj
@@ -1,0 +1,50 @@
+(ns vsts-flow-metrics.charts
+  (:require [com.hypirion.clj-xchart :as c]
+            [vsts-flow-metrics.core :as core]
+            [incanter.stats :as istats]))
+
+
+(def default-percentiles      [0.25              0.5      0.80              0.90])
+(def default-percentile-names ["25th percentile" "median" "80th percentile" "90th percentile"])
+
+(defn- percentiles-for-graph
+  ([item-names [pct25 median pct80 pct90 :as percentiles]]
+   (percentiles-for-graph item-names percentiles default-percentile-names))
+  ([item-names percentiles percentile-names]
+   (zipmap percentile-names (map (fn [p]
+                                   {:style {:render-style :line :marker-type :none}
+                                    :x item-names
+                                    :y (repeat (count item-names) p)})
+                                 percentiles))))
+
+
+(defn view-cycle-time
+  [work-item-intervals & {:keys [category-title
+                                 outliers
+                                 from-state
+                                 to-state]
+                          :or   {category-title "Dev Cycle Time"
+                                 outliers       #{}
+                                 from-state     "Active"
+                                 to-state       "Closed"}
+                          :as options}]
+  (let [valid-intervals (select-keys work-item-intervals
+                                     (remove outliers (keys work-item-intervals)))
+        cycle-time (core/cycle-times valid-intervals from-state to-state)
+        item-names (map name (keys cycle-time))
+        percentiles (istats/quantile (remove nil? (vals cycle-time)) :probs default-percentiles)
+        percentiles-graph-spec (percentiles-for-graph item-names percentiles)
+        chart (c/category-chart
+               (merge
+                {category-title (zipmap (map name (keys cycle-time)) (vals cycle-time))}
+                percentiles-graph-spec)
+
+               (merge {:title "Cycle time control chart"
+                       :series-order (apply vector category-title (reverse default-percentile-names))
+                       :x-axis {:title "Stories"}
+                       :y-axis {:title "Cycle time"
+                                :decimal-pattern "## days"}
+                       :theme :xchart} options))]
+
+    (c/view chart)
+    chart))

--- a/src/vsts_flow_metrics/cli.clj
+++ b/src/vsts_flow_metrics/cli.clj
@@ -1,0 +1,88 @@
+(ns vsts-flow-metrics.cli
+  (:require [clojure.tools.cli :as cli]
+            [clojure.java.io :as io]
+            [cheshire.core :as json]
+            [vsts-flow-metrics.core :as core]
+            [vsts-flow-metrics.storage :as storage]
+            [vsts-flow-metrics.config :as cfg]
+            [clojure.string :as string])
+  (:gen-class :main true))
+
+
+
+(defn- dump-usage
+  [cli-summary]
+  (binding [*out* *err*]
+    (println "USAGE:")
+    (println cli-summary)
+    (println "\nTools:
+    cache-changes <wiql-path> <Project> Queries work items specified in file <wiql-path> and save in cache folder. <Project> is the VSTS instance project to query, e.g. Mobile-Center.
+    ")))
+
+(def cli-options
+  [(comment ["-w" "--weekly-items WORK-ITEMS" "Commma separated list of work-item ids"
+             :parse-fn (fn [csl]
+                         (map #(Integer/parseInt %)
+                              (clojure.string/split csl #",")))])])
+
+
+(defn- check-file-exists!
+  [file]
+  (when-not (and file (.exists file))
+    (println "You must specify an existing file:" (str file))
+    (System/exit 1)))
+
+
+(defn cache-changes
+  [options args]
+  (let [[wiql-file-path project] args]
+    (when-not (and wiql-file-path (.exists (io/file wiql-file-path)))
+      (println "WIQL File does not exist:" wiql-file-path)
+      (throw (RuntimeException. (str "File does not exist:" wiql-file-path))))
+    (when-not (.isDirectory (io/file "cache"))
+      (println "Please create directory: cache")
+      (throw (RuntimeException. (str "No cache directory invalid"))))
+    (when (string/blank? project)
+      (println "Please specify a VSTS project name in the VSTS instance")
+      (throw (RuntimeException. (str "No project name specified"))))
+
+    (println "Query and cache WIQL" wiql-file-path)
+    (storage/cache-changes "wiql/closed-features-30d.wiql" project)))
+
+(defn -main
+  [& args]
+  (let [{:keys [options arguments summary errors]}
+        (cli/parse-opts args cli-options)]
+    (cond
+      errors (binding [*out* *err*]
+               (println "** Failed to parse command line options:" errors)
+               (dump-usage summary)
+               (System/exit 1))
+      (:help options) (do
+                        (dump-usage summary)
+                        (System/exit 0)))
+
+
+    (when (clojure.string/blank? (cfg/access-token))
+      (println "You must specify environment variable:" "VSTS_ACCESS_TOKEN")
+      (System/exit 1))
+
+    (when (clojure.string/blank? (:name (cfg/vsts-instance)))
+      (println "You must specify environment variable:" "VSTS_INSTANCE" " (for example export VSTS_INSTANCE=msmobilecenter.visualstudio.com)")
+      (System/exit 1))
+
+
+    ;; Launch selected tool
+    (try
+      (case (first arguments)
+        "cache-changes" (cache-changes options (rest arguments))
+        (binding [*out* *err*]
+          (println "** No such tool:" (first arguments))
+          (dump-usage summary)
+          (System/exit 1)))
+      (catch Exception e
+        (do
+          (println e "Uncaught throwable")
+          (if (System/getenv "DEBUG") (.printStackTrace e))
+          (System/exit 27))))
+    (System/exit 0)))

--- a/src/vsts_flow_metrics/config.clj
+++ b/src/vsts_flow_metrics/config.clj
@@ -1,0 +1,26 @@
+(ns vsts-flow-metrics.config
+  (:require [clojure.string :as string]
+            [clj-http.conn-mgr :as conn-mgr]))
+
+(defn- environment-config
+  [name]
+  (let [env (System/getenv name)]
+    (if (string/blank? env)
+      nil
+      env)))
+
+(defn access-token
+  []
+  (environment-config "ACCESS_TOKEN"))
+
+(def http-options
+  {:basic-auth (str ":" (access-token))
+   :socket-timeout 30000  ;; in milliseconds
+   :conn-timeout 10000
+   :connection-manager (conn-mgr/make-reusable-conn-manager {})
+   :accept :json})
+
+(defn vsts-instance
+  []
+  {:name (environment-config "VSTS_INSTANCE")
+   :http-options http-options})

--- a/src/vsts_flow_metrics/core.clj
+++ b/src/vsts_flow_metrics/core.clj
@@ -9,16 +9,19 @@
 
 
 (defn- map-values
-  [m f]
-  (reduce-kv (fn [m k v]
-               (assoc m k (f v))) {} m))
+  [f m]
+  (reduce-kv (fn [m k v] (assoc m k (f v))) {} m))
 
 
-(defn cycle-time-in-days
-  [state-intervals]
+(defn intervals-in-state
+  [work-items-changes]
+  (map-values work-items/intervals-in-state work-items-changes))
+
+(defn cycle-times
+  [state-intervals from-state to-state]
   (map-values
    (fn [intervals]
-     (let [cycle-time (work-items/dev-cycle-time intervals)]
+     (let [cycle-time (work-items/cycle-time intervals from-state to-state)]
        (if-let [cycle-time-hours (:hours cycle-time)]
          (/ cycle-time-hours 24.0))))
    state-intervals))

--- a/src/vsts_flow_metrics/storage.clj
+++ b/src/vsts_flow_metrics/storage.clj
@@ -1,0 +1,43 @@
+(ns vsts-flow-metrics.storage
+  (:require [vsts-flow-metrics.api :as api]
+            [vsts-flow-metrics.config :as cfg]
+            [clojure.java.io :as io]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [cheshire.core :as json]))
+
+
+(def file-format (f/formatters :date-hour-minute))
+
+(def as-of-format (f/formatter "MM/dd/yyyy"))
+
+(defn save-work-item-state-changes
+  [work-item-state-changes output-path]
+  (spit output-path (json/generate-string work-item-state-changes {:pretty true}))
+  (println "Saved work item state changes in " (.getAbsolutePath (io/file output-path)))
+  (.getAbsolutePath (io/file output-path)))
+
+(defn- load-work-item-state-changes [path]
+  (println "Loading work item state changes from " (.getAbsolutePath (io/file path)))
+  (json/parse-string (slurp (io/file path)) true))
+
+(defn load-state-changes-from-cache [json-file]
+  (if (.isAbsolute (io/file json-file))
+    (load-work-item-state-changes json-file)
+    (load-work-item-state-changes (str "cache/" json-file))))
+
+(defn work-item-state-changes
+  "Gets all state transition changes to a work item. NOTE: Makes one VSTS API call per work item."
+  [wiql-path project]
+  (let [wiql (slurp (io/file wiql-path))
+        work-items (api/query-work-items (cfg/vsts-instance) project wiql)
+        ids (map :id (:workItems work-items))
+        changes (map #(api/get-work-item-state-changes (cfg/vsts-instance) %) ids)]
+    (zipmap ids changes)))
+
+(defn cache-changes [wiql-path project]
+  (let [wiql-path-base (.getName (io/file wiql-path))
+        timestamp (t/now)]
+    (save-work-item-state-changes
+     (work-item-state-changes wiql-path project)
+     (str "cache/" (f/unparse file-format timestamp) "-" wiql-path-base ".json"))))

--- a/src/vsts_flow_metrics/work_items.clj
+++ b/src/vsts_flow_metrics/work_items.clj
@@ -1,0 +1,61 @@
+(ns vsts-flow-metrics.work-items
+  (:require [clojure.string :as s]
+            [clj-time.core :as t]
+            [clj-time.format :as f]))
+
+
+(defn cycle-time
+  "Computes cycle time from from-state to to-state, defined as
+   From the first time, the item transitioned into from-state
+   until the last time the item transitioned into to-state.
+  "
+  [state-intervals from-state to-state]
+  (if-let [begun (get state-intervals from-state)]
+    (if-let [closed (get state-intervals to-state)]
+      (let [first-begin (t/start (first begun))
+            last-closed (t/start (last closed))
+            interval (t/interval first-begin last-closed)]
+        {:interval interval
+         :days (t/in-days interval)
+         :hours (t/in-hours interval)}))))
+
+(defn intervals-in-state
+  "Maps a set of change records for a work item (i.e. VSTS updates)
+   to a map which maps states to a vector of intervals (the times where the work item
+  was in that state).
+  Inserts an implicit interval from when the item's last transition to now.
+  "
+  [change-records]
+  (let [compute-intervals
+        (fn [acc change]
+          (let [fields (:fields change)
+                {next-change-date :newValue} (:System.ChangedDate fields)
+                timestamp (if (re-matches #"^9999-.+" next-change-date) ;; "9999-01-01T00:00:00Z" means "now"
+                            (t/now)
+                            (try ;:date-time or :date-time-no-ms
+                              (f/parse (f/formatters :date-time) next-change-date)
+                              (catch java.lang.IllegalArgumentException e
+                                (f/parse (f/formatters :date-time-no-ms) next-change-date))))
+                last-board-state (:last-board-state acc)
+                last-timestamp (:last-timestamp acc)
+                {new-board-state :newValue}   (:System.State fields)
+                {new-board-column :newValue}  (:System.BoardColumn fields)
+                new-state (or new-board-column new-board-state)
+                next-acc  {:last-board-state new-state :last-timestamp timestamp}]
+            (if last-timestamp ;; i.e. this is not the first change made to the item
+              (if new-state
+                (let [duration (t/interval last-timestamp timestamp)
+                      board-state-duration (get acc last-board-state [])]
+                  (merge acc next-acc {last-board-state (conj board-state-duration duration)}))
+                acc)
+
+              next-acc)))]
+
+    (let [time-spent-by-state (reduce compute-intervals {} change-records)]
+      ;; create an extra synthetic event to represent now
+      ;; this ensures we calculate time spent in last known state
+      ;; until (t/now)
+      (compute-intervals time-spent-by-state
+         (update-in (last change-records)
+                    [:fields :System.ChangedDate :newValue]
+                    (constantly "9999-01-01T00:00:00Z"))))))

--- a/wiql/closed-features-30d.wiql
+++ b/wiql/closed-features-30d.wiql
@@ -15,8 +15,7 @@ WHERE
         [System.TeamProject] = @project
         AND [System.AreaPath] UNDER "Mobile-Center"
         AND [System.WorkItemType] IN ("Feature")
-        AND [System.State] <> "Closed"
-        AND [System.State] <> "Cancelled"
-ASOF   '3/16/2018'
+        AND [Microsoft.VSTS.Common.ClosedDate] >= @Today - 30
+        AND [System.State] IN ("Closed")
 
 ORDER BY [System.ChangedDate] DESC


### PR DESCRIPTION
Provides basic REPL support for cycle time control graph

```clojure
vsts-flow-metrics.core> (charts/view-cycle-time
                         (intervals-in-state
                          (storage/load-state-changes-from-cache
                           "2018-03-22T03:18-closed-features-30d.wiql.json"))
                         :title "Features closed (30d)"
                         :category-title "Cycle time"
                         :x-axis {:title "Features"})
Loading work item state changes from  /Users/krukow/code/vsts-flow-metrics/cache/2018-03-22T03:18-closed-features-30d.wiql.json
#object[org.knowm.xchart.CategoryChart 0x9bc65f7 "org.knowm.xchart.CategoryChart@9bc65f7"]
vsts-flow-metrics.core> 
```