### PR TITLE
Feature: System.BoardColumn, Doing/Done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ pom.xml
 pom.xml.asc
 *.jar
 *.class
+*.png
+*.svg
 /.lein-*
 /.nrepl-port
 .hgignore

--- a/README.md
+++ b/README.md
@@ -62,6 +62,31 @@ To see configuration options:
 $ ./flow-metrics show-config
 ```
 
+For example:
+```bash
+cat example-config-override.json
+{"project":"My-Project",
+ "cycle-time": {"field": "System.BoardColumn"},
+ "flow-efficiency" : {
+     "active-states" : [ "Active" ],
+     "blocked-states" : [ "Blocked", "In Review", "Deploying" ]}}
+
+$ VSTS_FLOW_CONFIG=example-config-override.json ./flow-metrics show-config
+{
+  "project" : "My-Project",
+  "cycle-time" : {
+    "from-state" : "Active",
+    "to-state" : "Closed",
+    "field" : "System.BoardColumn",
+    ...
+  }
+  "flow-efficiency" : {
+    "active-states" : [ "Active" ],
+    "blocked-states" : [ "Blocked", "In Review", "Deploying" ],
+    ...
+    }
+}
+```
 To use the tool for what you want, you'll almost certainly need to use configuration overrides.
 
 # Usage and How-To

--- a/example-config-override.json
+++ b/example-config-override.json
@@ -1,0 +1,5 @@
+{"project":"My-Project",
+ "cycle-time": {"field": "System.BoardColumn"},
+ "flow-efficiency" : {
+     "active-states" : [ "Active" ],
+     "blocked-states" : [ "Blocked", "In Review", "Deploying" ]}}

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -x
 set -e
+
+echo "Warning this requires private data: cache/2018-04-06T07:02-closed-stories-15d.wiql.json"
+echo "Warning this requires private data: cache/2018-04-06T07:11-closed-features-30d.wiql.json"
+
+echo "If you don't have this please generate your own data for smoke tests"
+echo "Running smoke tests"
+
 ./flow-metrics show-config
 
 ./flow-metrics flow-efficiency cache/2018-04-06T07:02-closed-stories-15d.wiql.json

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -x
+set -e
+./flow-metrics show-config
+
+./flow-metrics flow-efficiency cache/2018-04-06T07:02-closed-stories-15d.wiql.json
+
+./flow-metrics time-in-state cache/2018-04-06T07:11-closed-features-30d.wiql.json
+
+./flow-metrics cycle-time cache/2018-04-06T07:11-closed-features-30d.wiql.json --chart features-closed-30d-2018-04-06.svg
+
+./flow-metrics cycle-time cache/2018-04-06T07:11-closed-features-30d.wiql.json
+
+./flow-metrics responsiveness cache/2018-04-06T07:11-closed-features-30d.wiql.json
+
+./flow-metrics lead-time-distribution cache/2018-04-06T07:02-closed-stories-15d.wiql.json
+
+echo "Warning slow command uses API"
+./flow-metrics historic-queues wiql/features-as-of-template.wiql

--- a/src/vsts_flow_metrics/api.clj
+++ b/src/vsts_flow_metrics/api.clj
@@ -61,5 +61,7 @@
     (filter
      (fn [{fields :fields}]
        (or (:System.State fields)
-           (:System.BoardColumn fields)))
+           (:System.BoardColumn fields)
+           (:System.BoardLane fields)
+           (:System.BoardColumnDone fields)))
      (:value item-updates))))

--- a/src/vsts_flow_metrics/config.clj
+++ b/src/vsts_flow_metrics/config.clj
@@ -44,7 +44,6 @@
   {:name (environment-config "VSTS_INSTANCE")
    :http-options http-options})
 
-
 (defn deep-merge
   "Merges maps of similar shapes (used for default overriding config files).
   The default must have all the keys present."
@@ -62,6 +61,7 @@
    :cycle-time
    {:from-state "Active"
     :to-state "Closed"
+    :field :System.State ;;or :System.BoardColumn
     :chart {:title "Cycle time control chart"
             :width 1440
             :height 900
@@ -71,7 +71,8 @@
 
 
    :time-in-state
-   {:chart {:title "Time spent in state"
+   {:field :System.State ;; or :System.BoardColumn
+    :chart {:title "Time spent in state"
             :overlap? true
             :render-style :bar
             ;; this is optimized for features, customize to your team's needs!
@@ -91,6 +92,7 @@
    :flow-efficiency
    {:active-states ["Active"]
     :blocked-states ["Blocked" "In Review"]
+    :field :System.State ;;or :System.BoardColumn
     :chart {:title "Flow efficiency"
             :overlap? true
             :render-style :bar
@@ -104,6 +106,7 @@
    :responsiveness
    {:from-state "Ready for Work"
     :to-state "Active"
+    :field :System.State ;;or :System.BoardColumn
     :chart {:title "Responsiveness"
             :category-title "Responsiveness"
             :overlap? true
@@ -117,6 +120,7 @@
    :lead-time-distribution
    {:from-state "Active"
     :to-state   "Closed"
+    :field :System.State ;; or :System.BoardColumn
     :chart {:title "Lead Time Distribution"
             :category-title "Backlog items"
             :x-axis {:title "Lead time in days"}
@@ -127,6 +131,7 @@
    :historic-queues
    {:ago 30 ;; days
     :step 3 ;; day increments
+    :field :System.State ;; or :System.BoardColumn
     :chart {:title "Queue by state"
             :remove-states ["Closed" "Cancelled"]
             :series-order nil
@@ -142,3 +147,7 @@
 (defn config
   []
   (deep-merge default-config (load-config-from-file (config-file))))
+
+(defn vsts-field [key]
+  (let [field (get-in (config) [key :field])]
+    (keyword field)))

--- a/src/vsts_flow_metrics/config.clj
+++ b/src/vsts_flow_metrics/config.clj
@@ -90,7 +90,7 @@
 
    :flow-efficiency
    {:active-states ["Active"]
-    :blocked-states ["Blocked"]
+    :blocked-states ["Blocked" "In Review"]
     :chart {:title "Flow efficiency"
             :overlap? true
             :render-style :bar

--- a/wiql/closed-stories-15d.wiql
+++ b/wiql/closed-stories-15d.wiql
@@ -1,0 +1,21 @@
+SELECT
+        [System.Id],
+        [System.Rev],
+        [System.WorkItemType],
+        [System.Title],
+        [System.State],
+        [System.AreaPath],
+        [System.IterationPath],
+        [System.Description],
+        [System.AssignedTo],
+        [Microsoft.VSTS.Common.ClosedDate],
+        [System.Tags]
+FROM workitems
+WHERE
+        [System.TeamProject] = @project
+        AND [System.AreaPath] UNDER "Mobile-Center"
+        AND [System.WorkItemType] IN ("User Story")
+        AND [Microsoft.VSTS.Common.ClosedDate] >= @Today - 15
+        AND [System.State] IN ("Closed")
+
+ORDER BY [System.ChangedDate] DESC


### PR DESCRIPTION
Changes:

* VSTS field selection, e.g.  `"cycle-time": {"field": "System.BoardColumn"}`: `"System.BoardColumn"` or (default) `"System.State"`
* Support Doing/Done columns in Kanban boards
* More robust algorithm for computing time intervals spent in state
* Better documentation