### PR TITLE
Make cache optional

### DIFF
--- a/src/vsts_flow_metrics/storage.clj
+++ b/src/vsts_flow_metrics/storage.clj
@@ -32,7 +32,7 @@
         work-items (api/query-work-items (cfg/vsts-instance) project wiql)
         ids (map :id (:workItems work-items))
         changes (map #(api/get-work-item-state-changes (cfg/vsts-instance) %) ids)]
-    (zipmap ids changes)))
+    (zipmap (map (comp keyword str) ids) changes)))
 
 (defn cache-changes [wiql-path]
   (let [wiql-path-base (.getName (io/file wiql-path))


### PR DESCRIPTION
Allow use of a `.wiql` file any place where we previously only accepted a cache `.json` file.

e.g.

```bash
./flow-metrics cycle-time wiql/closed-features-30d.wiql --chart closed.svg
```