### PR TITLE
Adapt to new VSTS API using identity references

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -4,6 +4,7 @@ set -e
 
 echo "Warning this requires private data: cache/sample.json"
 
+cp ./resources/sample-data.json cache/sample.json
 echo "If you don't have this please generate your own data for smoke tests"
 echo "Running smoke tests"
 


### PR DESCRIPTION
VSTS changed its api for identifying who cast a vote on a PR.

We now use:

```
(get-in vote [:properties
                      :CodeReviewVotedByIdentity
                      :$value])
```

and look that up in `(:identities vote)`

This is backwards compat and still makes the old check