### PR TITLE
Feature: Support 'first queue time'

### DIFF
--- a/src/vsts_flow_metrics/charts.clj
+++ b/src/vsts_flow_metrics/charts.clj
@@ -49,7 +49,6 @@
        (c/view chart))
      chart)))
 
-
 (defn view-time-in-state
   ([times-in-states]
    (view-time-in-state times-in-states (default-chart-options :time-in-state)))

--- a/src/vsts_flow_metrics/charts.clj
+++ b/src/vsts_flow_metrics/charts.clj
@@ -6,8 +6,8 @@
             [clojure.java.io :as io]))
 
 
-(def default-percentiles      [0.25              0.5      0.80              0.90])
-(def default-percentile-names ["25th percentile" "median" "80th percentile" "90th percentile"])
+(def default-percentiles      [0.25              0.5      0.80              0.90              0.95])
+(def default-percentile-names ["25th percentile" "median" "80th percentile" "90th percentile" "95th percentile"])
 
 (defn- percentiles-for-graph
   ([item-names [pct25 median pct80 pct90 :as percentiles]]

--- a/src/vsts_flow_metrics/cli.clj
+++ b/src/vsts_flow_metrics/cli.clj
@@ -216,19 +216,18 @@ of that work item, and resolve that using the VSTS API."
                               core/intervals-in-state
                               normalize-query-results
                               core/first-queue-time)]
-      (cond
-        (:csv options)
+      (when (:csv options)
         (csv/write-fn-to-file csv/write-fn-to-file
                               first-queue-times
                               (:csv options)))
-
-        (:chart options)
+      (when (:chart options)
+        ;; note: cycle time graph is deliberately being reused here
         (charts/view-cycle-time (core/map-values :in-days first-queue-times)
-                                      (charts/default-chart-options :first-queue-time)
-                                      (:chart options))
-        :else
-        (print-result
-         (core/map-values :in-days first-queue-times)))))
+                                (charts/default-chart-options :first-queue-time)
+                                (:chart options)))
+      (when (and (nil? (:csv options))
+                 (nil? (:chart options)))
+        (print-result (core/map-values :in-days first-queue-times))))))
 
 
 

--- a/src/vsts_flow_metrics/cli.clj
+++ b/src/vsts_flow_metrics/cli.clj
@@ -218,7 +218,7 @@ of that work item, and resolve that using the VSTS API."
                               core/first-queue-time)]
       (when (:csv options)
         (csv/write-fn-to-file csv/write-fn-to-file
-                              first-queue-times
+                              csv/first-queue-times
                               (:csv options)))
       (when (:chart options)
         ;; note: cycle time graph is deliberately being reused here

--- a/src/vsts_flow_metrics/cli.clj
+++ b/src/vsts_flow_metrics/cli.clj
@@ -30,6 +30,8 @@
 
     time-in-state <spec>              - Times in states for a set of work-items defined by <spec> (see docs spec semantics). Use the --chart option to save a chart.
 
+    first-queue-time <spec>           - Calculates for a set of work-items defined by <spec>, the amount of time queued in a specific state (defined in the config). If a work-items has multiple occurrences of the state, the first occurrence is selected.
+
     flow-efficiency <spec>            - Flow efficiency for a set of work-items defined by <spec> (see docs spec semantics). Use the --chart option to save a chart. Or use the --csv <out.csv> to save data to a file in .csv format. Prints JSON format to stdout if no options specified.
 
     aggregate-flow-efficiency <spec>  - Aggregate flow efficiency for a set of work-items defined by <spec> (see docs spec semantics). Use the --chart option to save a chart. Or use the --csv <out.csv> to save data to a file in .csv format. Prints JSON format to stdout if no options specified.
@@ -205,6 +207,30 @@ of that work item, and resolve that using the VSTS API."
                                    (:chart options))
         :else
         (print-result times-in-states)))))
+
+(defn first-queue-time [options args]
+  (let [[work-items-spec] args]
+    (validate-work-items-spec! work-items-spec)
+
+    (let [first-queue-times (-> (load-state-changes work-items-spec)
+                              core/intervals-in-state
+                              normalize-query-results
+                              core/first-queue-time)]
+      (cond
+        (:csv options)
+        (csv/write-fn-to-file csv/write-fn-to-file
+                              first-queue-times
+                              (:csv options)))
+
+        (:chart options)
+        (charts/view-cycle-time (core/map-values :in-days first-queue-times)
+                                      (charts/default-chart-options :first-queue-time)
+                                      (:chart options))
+        :else
+        (print-result
+         (core/map-values :in-days first-queue-times)))))
+
+
 
 (defn responsiveness
   [options args]
@@ -417,6 +443,7 @@ of that work item, and resolve that using the VSTS API."
         "cache-work-item-changes" (cache-work-item-changes options (rest arguments))
         "cycle-time" (cycle-time options (rest arguments))
         "time-in-state" (time-in-state options (rest arguments))
+        "first-queue-time" (first-queue-time options (rest arguments))
         "flow-efficiency" (flow-efficiency options (rest arguments))
         "aggregate-flow-efficiency" (aggregate-flow-efficiency options (rest arguments))
         "responsiveness" (responsiveness options (rest arguments))

--- a/src/vsts_flow_metrics/cli.clj
+++ b/src/vsts_flow_metrics/cli.clj
@@ -215,19 +215,20 @@ of that work item, and resolve that using the VSTS API."
     (let [first-queue-times (-> (load-state-changes work-items-spec)
                               core/intervals-in-state
                               normalize-query-results
-                              core/first-queue-time)]
+                              core/first-queue-time)
+          time-in-days (core/map-values :in-days first-queue-times)]
       (when (:csv options)
-        (csv/write-fn-to-file csv/write-fn-to-file
-                              csv/first-queue-times
+        (csv/write-fn-to-file csv/first-queue-times
+                              time-in-days
                               (:csv options)))
       (when (:chart options)
         ;; note: cycle time graph is deliberately being reused here
-        (charts/view-cycle-time (core/map-values :in-days first-queue-times)
+        (charts/view-cycle-time time-in-days
                                 (charts/default-chart-options :first-queue-time)
                                 (:chart options)))
       (when (and (nil? (:csv options))
                  (nil? (:chart options)))
-        (print-result (core/map-values :in-days first-queue-times))))))
+        (print-result time-in-days)))))
 
 
 

--- a/src/vsts_flow_metrics/config.clj
+++ b/src/vsts_flow_metrics/config.clj
@@ -88,6 +88,7 @@
    :first-queue-time
    {:state "Escalated"
     :field :System.State ;;or :System.BoardColumn
+    :business-days true
     :chart {:title "Time in queue (first occurrence only)"
             :category-title "Queue time"
             :width 1440

--- a/src/vsts_flow_metrics/config.clj
+++ b/src/vsts_flow_metrics/config.clj
@@ -85,6 +85,16 @@
 
             :theme :xchart}}
 
+   :first-queue-time
+   {:state "Escalated"
+    :field :System.State ;;or :System.BoardColumn
+    :chart {:title "Time in queue (first occurrence only)"
+            :category-title "Queue time"
+            :width 1440
+            :height 900
+            :x-axis {:title "Work items"}
+            :y-axis {:title "Time in queue" :decimal-pattern "##.# days"}
+            :theme :xchart}}
 
    :flow-efficiency
    {:active-states ["Active"]

--- a/src/vsts_flow_metrics/core.clj
+++ b/src/vsts_flow_metrics/core.clj
@@ -107,13 +107,17 @@
                                     state-int (if (sequential? state-ints)
                                                 (first state-ints)
                                                 state-ints)
-                                    state-int (if business-days
-                                                (utils/adjust-for-business-time state-int)
-                                                state-int)]
-                                {:interval state-int
-                                 :in-days (/ (t/in-hours state-int) 24.0)
-                                 :in-hours (t/in-hours state-int)}))
-                            state-intervals)])))
+                                    state-ints (if business-days
+                                                 (utils/adjust-for-business-time state-int)
+                                                 (list state-int))
+                                    hours (reduce + 0 (map t/in-hours state-ints))
+
+                                    ]
+                                {:intervals state-ints
+                                 :in-days (/ hours 24.0)
+                                 :in-hours hours}))
+                            state-intervals)]
+     first-queue-times)))
 
 (defn lead-time-distribution
   ([state-intervals]

--- a/src/vsts_flow_metrics/core.clj
+++ b/src/vsts_flow_metrics/core.clj
@@ -92,6 +92,29 @@
                                                     from-state to-state))
     state-intervals)))
 
+(defn first-queue-time
+  "Computes time spent queued in `state`. If there are multiple occurrences of `state`,
+  `first-queue-time` only considers the time queued the first time in state `state`"
+  ([state-intervals] (first-queue-time state-intervals (:first-queue-time (cfg/config))))
+  ([state-intervals {:keys [state field business-days]}]
+   (let [first-queue-times (map-values
+                            (fn [time-spent-data]
+                              (let [now (t/now)
+                                    empty-int (t/interval now now)
+                                    state-ints (get-in time-spent-data
+                                                       [(keyword field) state]
+                                                       empty-int)
+                                    state-int (if (sequential? state-ints)
+                                                (first state-ints)
+                                                state-ints)
+                                    state-int (if business-days
+                                                (utils/adjust-for-business-time state-int)
+                                                state-int)]
+                                {:interval state-int
+                                 :in-days (/ (t/in-hours state-int) 24.0)
+                                 :in-hours (t/in-hours state-int)}))
+                            state-intervals)])))
+
 (defn lead-time-distribution
   ([state-intervals]
    (lead-time-distribution state-intervals (:lead-time-distribution (cfg/config))))

--- a/src/vsts_flow_metrics/csv.clj
+++ b/src/vsts_flow_metrics/csv.clj
@@ -77,6 +77,36 @@
                    ]
                   valid-cycle-times)))
 
+(defn first-queue-times
+  [queue-times]
+  (let [valid-times
+        (remove #(nil? (second %)) queue-times)
+        percentiles (istats/quantile (remove #(zero? %) (vals valid-times))
+                                     :probs [0.1 0.2 0.30 0.5 0.80 0.9 0.95])]
+    (project-rows [{:header "Work Item"
+                    :fn (fn [[id val]] (str "#" (name id)))}
+                   {:header "Queue-time"
+                    :fn (fn [[id val]] (float val))}
+                   {:header "Link"
+                    :fn (fn [[id val]] (work-item-link id))}
+
+                   {:header "10th percentile"
+                    :fn (constantly (nth percentiles 0))}
+                   {:header "20th percentile"
+                    :fn (constantly (nth percentiles 1))}
+                   {:header "30th percentile"
+                    :fn (constantly (nth percentiles 2))}
+                   {:header "median"
+                    :fn (constantly (nth percentiles 3))}
+                   {:header "80th percentile"
+                    :fn (constantly (nth percentiles 4))}
+                   {:header "90th percentile"
+                    :fn (constantly (nth percentiles 5))}
+                   {:header "95th percentile"
+                    :fn (constantly (nth percentiles 6))}
+                   ]
+                  valid-times)))
+
 (defn write-fn-to-file
   [f values filename]
   (with-open [writer (io/writer filename)]

--- a/src/vsts_flow_metrics/utils.clj
+++ b/src/vsts_flow_metrics/utils.clj
@@ -117,7 +117,8 @@
 
 (defn merge-intervals
   [sorted-intervals]
-  (let [merger (fn [{current :current :as acc} interval]
+  (if (seq sorted-intervals)
+    (let [merger (fn [{current :current :as acc} interval]
                  (if-let [o (t/overlap current interval)]
                    (let [s1 (t/start current)
                          e1 (t/end current)
@@ -131,7 +132,9 @@
         merged (reduce merger
                        {:current (first sorted-intervals) :res []}
                        sorted-intervals)]
-    (conj (:res merged) (:current merged))))
+      (conj (:res merged) (:current merged)))
+
+    sorted-intervals))
 
 (defn adjust-for-business-time
   [interval]
@@ -142,6 +145,7 @@
                               (weekends s e))
         sorted-free-time (sort-by t/start (concat free-intervals weekend-overlaps))
         maximal-intervals (merge-intervals sorted-free-time)
+
         business-time-reducer (fn [{s :current :as acc} next-holiday]
                                 (let [sh (t/start next-holiday)
                                       eh (t/end   next-holiday)]

--- a/src/vsts_flow_metrics/utils.clj
+++ b/src/vsts_flow_metrics/utils.clj
@@ -106,13 +106,7 @@
 
 (defn vacations-and-holiday-overlap
   [interval]
-  (let [start-at (t/start interval)
-        end-at (t/end interval)
-
-        ;; weekends that overlap with this interval
-        relevant-weekends (weekends start-at (t/plus end-at (t/days 1)))
-        vacation-overlaps (danish-vacation-days-overlap interval)]
-    (remove nil? vacation-overlaps)))
+  (remove nil? (danish-vacation-days-overlap interval)))
 
 
 (defn merge-intervals

--- a/src/vsts_flow_metrics/utils.clj
+++ b/src/vsts_flow_metrics/utils.clj
@@ -1,6 +1,8 @@
 (ns vsts-flow-metrics.utils
   (:require [clj-time.core :as t]
-            [clj-time.format :as f]))
+            [clj-time.format :as f]
+            [clj-time.predicates :as t-pr]
+            [clj-time.periodic :as p]))
 
 (defn parse-time-stamp
   [date-s]
@@ -18,3 +20,138 @@
 
         :else
         (throw (RuntimeException. (str "Unexpected type for " date-s)))))
+
+(def danish-time-zone (t/time-zone-for-id "Europe/Copenhagen"))
+
+;http://www.hildeberto.com/2016/11/how-does-easter-feast-change-every-year.html
+(defn calculate-easter-date [year]
+  (if (< year 1583)
+    (throw (IllegalArgumentException.
+               "Year must be greater than 1582"))
+    (let [a (rem  year 19)
+          b (quot year 100)
+          c (rem  year 100)
+          d (quot b 4)
+          e (rem  b 4)
+          f (quot (+ b 8) 25)
+          g (quot (+ b (- f) 1) 3)
+          h (rem  (+ (* 19 a) b (- d) (- g) 15) 30)
+          i (quot c 4)
+          k (rem  c 4)
+          l (rem  (+ 32 (* 2 e) (* 2 i) (- h) (- k)) 7)
+          m (quot (+ a (* 11 h) (* 22 l)) 451)
+          n (quot (+ h l (- (* 7 m)) 114) 31)
+          p (rem  (+ h l (- (* 7 m)) 114) 31)]
+      (t/from-time-zone (t/date-time year n (inc p)) danish-time-zone))))
+
+
+
+(defn danish-vacation-days [year]
+  ;;https://da.wikipedia.org/wiki/Danske_helligdage
+  (let [fixed #{(t/interval ;; 1. januar Nytårsdag
+                 (t/from-time-zone (t/date-time year 1 1) danish-time-zone)
+                 (t/from-time-zone (t/date-time year 1 2) danish-time-zone))
+                (t/interval ;; Julen
+                 (t/from-time-zone (t/date-time year 12 25) danish-time-zone)
+                 (t/from-time-zone (t/date-time year 12 27) danish-time-zone))}
+
+        easter-sun (calculate-easter-date year)
+        easter (t/interval
+                (t/from-time-zone (t/minus easter-sun (t/days 3)) danish-time-zone) ;Skærtorsdag
+                (t/from-time-zone (t/plus  easter-sun (t/days 2)) danish-time-zone) ; end of 2. påskedag
+                )
+
+        prayer-day  ;Store bededag: fredagen 3 uger og 5 dage efter påskedag.
+        (t/interval
+         (t/plus easter-sun (t/weeks 3) (t/days 5))
+         (t/plus easter-sun (t/weeks 3) (t/days 6)))
+
+        kristi-hf-day ;Kristi himmelfartsdag: torsdagen 5 uger og 4 dage efter påskedag.
+        (t/interval
+         (t/plus easter-sun (t/weeks 5) (t/days 4))
+         (t/plus easter-sun (t/weeks 5) (t/days 5)))
+
+        pinsen ;; Pinsedag (til minde om Helligåndens komme): søndagen 7 uger efter påskedag.
+               ;; Anden pinsedag: dagen efter pinsedag.
+        (t/interval
+         (t/plus easter-sun (t/weeks 7))
+         (t/plus easter-sun (t/weeks 7) (t/days 2)))]
+
+    (conj fixed easter prayer-day kristi-hf-day pinsen)))
+
+
+(defn danish-vacation-days-overlap
+  [interval]
+  (let [years (range (t/year (t/start interval))
+                     (inc (t/year (t/end interval))))
+        vacation-ints (mapcat #(danish-vacation-days %) years)]
+    (->> vacation-ints
+         (map #(t/overlap interval %))
+         (remove nil?))))
+
+(defn weekends [start end]
+  (let [normalized-start (t/with-time-at-start-of-day start)
+        day-of-week (t/day-of-week normalized-start)
+        next-mon (t/plus normalized-start
+                         (t/days (- 8 day-of-week)))
+        real-end (if (t-pr/weekend? end)
+                   (t/plus (t/with-time-at-start-of-day end)
+                           (t/days (- 8 day-of-week))) ; next mon if in weekend
+                   end)
+        weekend-start (t/plus normalized-start
+                              (t/days (- 6 day-of-week)))
+        starts (p/periodic-seq weekend-start real-end (t/days 7))
+        ends   (p/periodic-seq next-mon      real-end (t/days 7))]
+    (map (fn [start end] (t/interval start end)) starts ends)))
+
+(defn vacations-and-holiday-overlap
+  [interval]
+  (let [start-at (t/start interval)
+        end-at (t/end interval)
+
+        ;; weekends that overlap with this interval
+        relevant-weekends (weekends start-at (t/plus end-at (t/days 1)))
+        vacation-overlaps (danish-vacation-days-overlap interval)]
+    (remove nil? vacation-overlaps)))
+
+
+(defn merge-intervals
+  [sorted-intervals]
+  (let [merger (fn [{current :current :as acc} interval]
+                 (if-let [o (t/overlap current interval)]
+                   (let [s1 (t/start current)
+                         e1 (t/end current)
+                         s2 (t/start interval)
+                         e2 (t/end interval)
+                         extended (t/interval s1 (t/max-date e1 e2))]
+                     (assoc acc :current extended))
+                   (-> acc
+                       (update :res conj current)
+                       (assoc :current interval))))
+        merged (reduce merger
+                       {:current (first sorted-intervals) :res []}
+                       sorted-intervals)]
+    (conj (:res merged) (:current merged))))
+
+(defn adjust-for-business-time
+  [interval]
+  (let [s (t/start interval)
+        e (t/end interval)
+        free-intervals (vacations-and-holiday-overlap interval)
+        weekend-overlaps (map #(t/overlap interval %)
+                              (weekends s e))
+        sorted-free-time (sort-by t/start (concat free-intervals weekend-overlaps))
+        maximal-intervals (merge-intervals sorted-free-time)
+        business-time-reducer (fn [{s :current :as acc} next-holiday]
+                                (let [sh (t/start next-holiday)
+                                      eh (t/end   next-holiday)]
+                                  (if-not (t/within? next-holiday s)
+                                    (-> acc
+                                        (update :res conj (t/interval s sh))
+                                        (assoc :current eh))
+                                    (assoc acc :current eh))))
+        business-time-intervals (reduce business-time-reducer
+                                        {:current s :res []}
+                                        maximal-intervals)]
+    (conj (:res business-time-intervals)
+          (t/interval (:current business-time-intervals) e)) ))

--- a/src/vsts_flow_metrics/utils.clj
+++ b/src/vsts_flow_metrics/utils.clj
@@ -154,4 +154,4 @@
                                         {:current s :res []}
                                         maximal-intervals)]
     (conj (:res business-time-intervals)
-          (t/interval (:current business-time-intervals) e)) ))
+          (t/interval (:current business-time-intervals) e))))


### PR DESCRIPTION
Support computing business days time spent in state ('queue time') for work items. For example, how long is a support escalation request queued before being picked up by the team escalated to.

```
./flow-metrics first-queue-time wiql/closed-issues-Mads-Team-30d.wiql --chart example.svg
```

Note: this is limited preview and supports computation for `first-queue-time` considering only danish business days. 


